### PR TITLE
Add masonry layout for portfolio cards

### DIFF
--- a/archive-portfolio.php
+++ b/archive-portfolio.php
@@ -5,7 +5,8 @@
  * Template Post Type: page
  */
 
-// Страница архива портфолио с реализованными проектами.
+// Страница архива портфолио с реализованными проектами,
+// использует masonry-сетку для карточек.
 include 'header.php';
 
 ?>
@@ -169,7 +170,7 @@ include 'header.php';
 
 
 		<div class="container">
-			<div class="row">
+                                <div class="row">
 				<div class="col-lg-7 offset-lg-1">
 					<h1>Наши <span>работы</span></h1>
 					<ul class="main-list">
@@ -380,7 +381,7 @@ include 'header.php';
 						</div>
 					</div>
 				</div>
-				<div class="row">
+				<div class="row portfolio-grid">
 					<?php
 					$args = [
 						'post_type' => 'portfolio',

--- a/css/theme.css
+++ b/css/theme.css
@@ -814,7 +814,7 @@ a.btn.btn-danger:focus {
 }
 
 .portfolio-section .single-product-img {
-	height: 500px;
+        height: auto;
 }
 
 .portfolio-section .carousel-control-prev-icon {
@@ -831,12 +831,12 @@ a.btn.btn-danger:focus {
 }
 
 .portfolio-section .approximation img {
-	width: 100%;
-	height: 100%;
-	transition: 0.3s all ease;
-	transform: scale(1);
-	object-fit: cover;
-	object-position: center;
+        width: 100%;
+        height: auto;
+        transition: 0.3s all ease;
+        transform: scale(1);
+        object-fit: cover;
+        object-position: center;
 }
 
 .portfolio-section .light {
@@ -884,14 +884,39 @@ a.btn.btn-danger:focus {
 }
 
 .nav-scroller .nav {
-	display: flex;
-	flex-wrap: nowrap;
-	padding-bottom: 1rem;
-	margin-top: -1px;
-	overflow-x: auto;
-	text-align: center;
-	white-space: nowrap;
-	-webkit-overflow-scrolling: touch;
+        display: flex;
+        flex-wrap: nowrap;
+        padding-bottom: 1rem;
+        margin-top: -1px;
+        overflow-x: auto;
+        text-align: center;
+        white-space: nowrap;
+        -webkit-overflow-scrolling: touch;
+}
+
+/* Masonry layout for portfolio cards */
+.portfolio-grid {
+        column-count: 4;
+        column-gap: 30px;
+}
+
+@media (max-width: 1199.98px) {
+        .portfolio-grid {
+                column-count: 3;
+        }
+}
+
+@media (max-width: 767.98px) {
+        .portfolio-grid {
+                column-count: 2;
+        }
+}
+
+.portfolio-grid > div {
+        width: 100%;
+        display: block;
+        break-inside: avoid;
+        margin-bottom: 30px;
 }
 /*** END PORTFOLIO SECTION ***/
 

--- a/dveri-cupe.php
+++ b/dveri-cupe.php
@@ -5,7 +5,7 @@
  * Template Post Type: page
  */
 
-// Шаблон страницы с описанием дверей-купе.
+// Шаблон страницы с описанием дверей-купе, содержит masonry-галерею.
 include 'header.php';
 
 ?>
@@ -326,7 +326,7 @@ include 'header.php';
 <section class="section-video">
 	<div class="container"
 		style="max-width: 1700px; padding-top: 80px; padding-bottom: 50px; border-right: 1px solid rgba(153, 153, 153, 0.9);  border-left: 1px solid rgba(153, 153, 153, 0.9);">
-		<div class="row justify-content-center">
+                                <div class="row justify-content-center portfolio-grid">
 			<div class="col-md-9">
 				<h2><span>01</span> / Посмотрите нашу видеопрезентацию</h2>
 				<div class="row justify-content-center">

--- a/garderobnye.php
+++ b/garderobnye.php
@@ -5,7 +5,7 @@
  * Template Post Type: page
  */
 
-// Шаблон страницы с примерами гардеробных.
+// Шаблон страницы с примерами гардеробных, содержит masonry-галерею.
 include 'header.php';
 
 ?>
@@ -330,7 +330,7 @@ include 'header.php';
 <section class="section-video">
 	<div class="container"
 		style="max-width: 1700px; padding-top: 80px; padding-bottom: 50px; border-right: 1px solid rgba(153, 153, 153, 0.9);  border-left: 1px solid rgba(153, 153, 153, 0.9);">
-		<div class="row justify-content-center">
+                                <div class="row justify-content-center portfolio-grid">
 			<div class="col-md-9">
 				<h2><span>01</span> / Посмотрите нашу видеопрезентацию</h2>
 				<div class="row justify-content-center">

--- a/rabochie-zony.php
+++ b/rabochie-zony.php
@@ -5,7 +5,7 @@
  * Template Post Type: page
  */
 
-// Шаблон страницы рабочих зон офиса.
+// Шаблон страницы рабочих зон офиса, содержит masonry-галерею.
 include 'header.php';
 
 ?>
@@ -330,7 +330,7 @@ include 'header.php';
 <section class="section-video">
 	<div class="container"
 		style="max-width: 1700px; padding-top: 80px; padding-bottom: 50px; border-right: 1px solid rgba(153, 153, 153, 0.9);  border-left: 1px solid rgba(153, 153, 153, 0.9);">
-		<div class="row justify-content-center">
+                                <div class="row justify-content-center portfolio-grid">
 			<div class="col-md-9">
 				<h2><span>01</span> / Посмотрите нашу видеопрезентацию</h2>
 				<div class="row justify-content-center">

--- a/shkafy-cupe.php
+++ b/shkafy-cupe.php
@@ -5,7 +5,7 @@
  * Template Post Type: page
  */
 
-// Шаблон страницы с примерами шкафов-купе.
+// Шаблон страницы с примерами шкафов-купе, содержит masonry-галерею.
 include 'header.php';
 
 ?>
@@ -328,7 +328,7 @@ include 'header.php';
 <section class="section-video">
 	<div class="container"
 		style="max-width: 1700px; padding-top: 80px; padding-bottom: 50px; border-right: 1px solid rgba(153, 153, 153, 0.9);  border-left: 1px solid rgba(153, 153, 153, 0.9);">
-		<div class="row justify-content-center">
+                                        <div class="row justify-content-center portfolio-grid">
 			<div class="col-md-9">
 				<h2><span>01</span> / Посмотрите нашу видеопрезентацию</h2>
 				<div class="row justify-content-center">

--- a/shkafy-raspashnye.php
+++ b/shkafy-raspashnye.php
@@ -5,7 +5,7 @@
  * Template Post Type: page
  */
 
-// Шаблон страницы с примерами распашных шкафов.
+// Шаблон страницы с примерами распашных шкафов, содержит masonry-галерею.
 include 'header.php';
 
 ?>
@@ -326,7 +326,7 @@ include 'header.php';
 <section class="section-video">
 	<div class="container"
 		style="max-width: 1700px; padding-top: 80px; padding-bottom: 50px; border-right: 1px solid rgba(153, 153, 153, 0.9);  border-left: 1px solid rgba(153, 153, 153, 0.9);">
-		<div class="row justify-content-center">
+                                <div class="row justify-content-center portfolio-grid">
 			<div class="col-md-9">
 				<h2><span>01</span> / Посмотрите нашу видеопрезентацию</h2>
 				<div class="row justify-content-center">

--- a/taxonomy-portfolio-cat.php
+++ b/taxonomy-portfolio-cat.php
@@ -6,7 +6,8 @@
 	 */
 	 
 	include 'header.php';
-// Отображает элементы портфолио, отфильтрованные по категории.
+// Отображает элементы портфолио, отфильтрованные по категории,
+// использует masonry-сетку для карточек.
 	 
 ?>
 <!-- SECTION HOME -->
@@ -161,7 +162,7 @@
 	
 	
 		<div class="container">
-			<div class="row">
+                                <div class="row portfolio-grid">
 				<div class="col-lg-7 offset-lg-1">
 					<h1>Наши <span>работы</span></h1>
 					<ul class="main-list">


### PR DESCRIPTION
## Summary
- tweak portfolio card styles for masonry layout
- update PHP templates with `portfolio-grid` rows
- note masonry layout in template descriptions

## Testing
- `php -l archive-portfolio.php`
- `php -l taxonomy-portfolio-cat.php`
- `php -l garderobnye.php`
- `php -l shkafy-cupe.php`
- `php -l shkafy-raspashnye.php`
- `php -l dveri-cupe.php`
- `php -l rabochie-zony.php`


------
https://chatgpt.com/codex/tasks/task_e_6880a5f7b2748326a7891ed3af62bc38